### PR TITLE
Fix #16: StringSearchInterpolator does not cache answers.

### DIFF
--- a/src/main/java/org/codehaus/plexus/interpolation/StringSearchInterpolator.java
+++ b/src/main/java/org/codehaus/plexus/interpolation/StringSearchInterpolator.java
@@ -156,7 +156,7 @@ public class StringSearchInterpolator implements Interpolator {
 
                     recursionInterceptor.expressionResolutionStarted(realExpr);
                     try {
-                        Object value = existingAnswers.get(realExpr);
+                        Object value = getExistingAnswer(realExpr);
                         Object bestAnswer = null;
 
                         for (ValueSource valueSource : valueSources) {
@@ -197,6 +197,10 @@ public class StringSearchInterpolator implements Interpolator {
                             // behaviour
                             result.append(String.valueOf(value));
                             resolved = true;
+
+                            if (cacheAnswers) {
+                                existingAnswers.put(realExpr, value);
+                            }
                         } else {
                             unresolvable.add(wholeExpr);
                         }
@@ -274,5 +278,14 @@ public class StringSearchInterpolator implements Interpolator {
 
     public void setEscapeString(String escapeString) {
         this.escapeString = escapeString;
+    }
+
+    /**
+     * For testing purposes only. Not part of the public API.
+     * @param key the key of a possible existing answer.
+     * @return the associated interpolated object, or null if there is none.
+     */
+    protected Object getExistingAnswer(String key) {
+        return existingAnswers.get(key);
     }
 }


### PR DESCRIPTION
- Added tests exposing the issue.
- Fixed code.
- Added missing @Override annotations.