### PR TITLE
Bump maven-project-info-reports-plugin to 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,16 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!-- remove with parent update, fix for ${localRepository} -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.9.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
To avoid warnings about using ${localRepository}