### PR TITLE
Restore the document metadata dropped when the page was ported

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,11 @@
+---
+title: Plexus Interpolator
+author:
+  - John Casey
+  - Hervé Boutemy
+date: 2012-10-31
+---
+
 # Introduction
 
 Plexus interpolator is the outgrowth of multiple iterations of development focused on providing a more modular, flexible interpolation framework for the expression language style commonly seen in Maven, Plexus, and other related projects.


### PR DESCRIPTION
Unblocked by the release of plexus parent 26.

The APT source carried a title, an author and a date. Converting the page to Markdown
dropped them, so the generated page lost its `<title>` and its author meta. This puts
them back as YAML front matter, read from the deleted `src/site/apt/index.apt`:
authors John Casey and Hervé Boutemy, dated 2012-10-31.

It could not be done before now: parent 25 runs Spotless over `**/*.md`, and flexmark
rewrites the fence closing a front matter block, silently costing the page the very
metadata being restored. Parent 26 excludes `**/src/site/markdown/**`, so the first
commit here is the parent upgrade.

Verified after the bump — front matter survives the build and the page carries both:

```
<title>Plexus Interpolator – Plexus Interpolation API</title>
<meta name="author" content="John Casey" />
<meta name="author" content="Hervé Boutemy" />
```