### PR TITLE
Rewrite README with usage, status and version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,49 @@
-Plexus-Interpolation
-====================
+# Plexus Interpolation
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-interpolation.svg?label=Maven%20Central)](http://search.maven.org/artifact/org.codehaus.plexus/plexus-interpolation)
+[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-interpolation.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.codehaus.plexus/plexus-interpolation)
+[![GitHub CI](https://github.com/codehaus-plexus/plexus-interpolation/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-interpolation/actions)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/codehaus/plexus/plexus-interpolation/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/codehaus/plexus/plexus-interpolation/README.md)
 
-The current master is now at https://github.com/codehaus-plexus/plexus-interpolation
+Resolves `${...}` expressions in strings. This is the engine behind POM interpolation — when Maven turns
+`${project.version}` in your POM into an actual version, this is what does it.
 
-Components for interpolating `${}` strings and the like.
+Expression sources are stackable, so you can resolve against a model object, then system properties, then
+the environment, in a defined order; cycle detection and synonym prefixes (`${pom.x}` and `${project.x}`)
+are built in.
 
-For publishing [the site](https://codehaus-plexus.github.io/plexus-interpolation/) do the following:
+It began as a package inside `plexus-utils` and was split out so the two could version independently.
 
+## Status
+
+Maintained, conservatively. The API is stable and very widely depended on transitively — changes are
+mostly bug fixes.
+
+## Using it
+
+```xml
+<dependency>
+  <groupId>org.codehaus.plexus</groupId>
+  <artifactId>plexus-interpolation</artifactId>
+  <version>1.29</version>
+</dependency>
 ```
-mvn -Preporting verify site-deploy
-```
 
+Check the badge above for the current version.
+
+## Requirements
+
+Java 8 or later.
+
+## Documentation
+
+- [Project site](https://codehaus-plexus.github.io/plexus-interpolation/) — includes a worked example of the configuration Maven uses
+- [Javadoc](https://javadoc.io/doc/org.codehaus.plexus/plexus-interpolation)
+- [Release notes](https://github.com/codehaus-plexus/plexus-interpolation/releases)
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/codehaus-plexus/.github/blob/master/CONTRIBUTING.md). In short:
+`mvn verify` builds, and run `mvn spotless:apply` before pushing or CI will fail on formatting.
+
+Please report security vulnerabilities privately — see
+[SECURITY.md](https://github.com/codehaus-plexus/.github/blob/master/SECURITY.md), not a public issue.


### PR DESCRIPTION
Part of codehaus-plexus/.github#58. Same skeleton as the merged pilots.

The old README said this was "the outgrowth of multiple iterations of development focused on providing a more modular, flexible interpolation framework" — which describes the project's history rather than what it does.

It now leads with the thing that makes it recognisable:

> This is the engine behind POM interpolation — when Maven turns `${project.version}` in your POM into an actual version, this is what does it.

Plus the stackable value sources, cycle detection and synonym prefixes in a sentence, since those are the features that distinguish it from a regex replace.

Also adds the dependency snippet, the Java baseline and doc links, and drops the 2015 redirect line and the publish recipe (now in [RELEASING.md](https://github.com/codehaus-plexus/.github/blob/master/RELEASING.md)).

Ran `mvn spotless:apply`.