### PR TITLE
Describe the artifact in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
   <packaging>bundle</packaging>
 
   <name>Plexus Interpolation API</name>
+  <description>A component that resolves expressions in strings against stackable value sources, as used for
+    POM interpolation.</description>
 
   <scm>
     <connection>scm:git:https://github.com/codehaus-plexus/plexus-interpolation.git</connection>


### PR DESCRIPTION
With no `<description>`, the generated site homepage inherits the parent's: *"The Plexus project provides a full software stack for creating and executing software projects."* That describes the retired IoC container, not this artifact, and it is also what Central shows.

Wording follows the README opening and matches the noun-phrase form the other components use.

*This change was created with AI assistance.*